### PR TITLE
chore: consolidate bash-reviewer security + DRY branches

### DIFF
--- a/.claude/skills/bash-reviewer/SKILL.md
+++ b/.claude/skills/bash-reviewer/SKILL.md
@@ -48,6 +48,7 @@ Produces a structured report with fixes sourced from reference documentation.
 - Security: eval injection, unvalidated command expansion
 - Portability: sed -i, grep -P, readarray/mapfile, find -o precedence
 - Robustness: division by zero, wc in arithmetic, missing prerequisite checks, set -euo pitfalls
+- DRY: repeated check/counter blocks, duplicated scan loops, shared constants across files
 
 **DON'T review:**
 
@@ -91,34 +92,45 @@ For each script, use `Grep` to scan for pattern signatures:
 | Case-restricted security cls  | `\[A-Z_\].*(TOKEN\|KEY\|SECRET)`      | Security    |
 | Text-only extension filter    | `find.*-name.*\.md.*-o.*-name.*\.sh`  | Security    |
 | Suppression w/o allowlist     | `is_nolint\|is_suppressed\|# noqa`    | Security    |
+| Repeated check+counter block  | `check_result=\$\?`                   | DRY         |
+| Repeated scan/grep loop       | `while.*read.*grep.*done`             | DRY         |
+| Repeated format+counter       | `\(\(.*\+\+\)\).*\|\| true`           | DRY         |
+| Duplicated constants/utils    | `RED=.*033` in multiple files         | DRY         |
+| Missing shellcheck source     | `source.*\.sh`                        | Robustness  |
 
 ### Step 3: Read References
 
 For each detected anti-pattern, **READ** the corresponding reference file:
 
-| Category    | Anti-Pattern                           | Reference                                                             |
-| ----------- | -------------------------------------- | --------------------------------------------------------------------- |
-| Security    | eval with untrusted input              | [eval-injection.md](references/eval-injection.md)                     |
-| Security    | Unvalidated command expansion          | [eval-injection.md](references/eval-injection.md)                     |
-| Portability | Platform-specific sed flags            | [portable-sed-and-tools.md](references/portable-sed-and-tools.md)     |
-| Portability | grep -P (Perl regex)                   | [portable-sed-and-tools.md](references/portable-sed-and-tools.md)     |
-| Portability | readarray/mapfile without bash 4 check | [portable-sed-and-tools.md](references/portable-sed-and-tools.md)     |
-| Portability | find -o without grouping               | [find-operator-precedence.md](references/find-operator-precedence.md) |
-| Robustness  | Division without zero check            | [arithmetic-guards.md](references/arithmetic-guards.md)               |
-| Robustness  | wc output in arithmetic                | [arithmetic-guards.md](references/arithmetic-guards.md)               |
-| Robustness  | Missing prerequisite checks            | [prerequisite-checks.md](references/prerequisite-checks.md)           |
-| Robustness  | set -euo edge cases                    | [set-euo-pitfalls.md](references/set-euo-pitfalls.md)                 |
-| Robustness  | grep in pipeline under pipefail        | [set-euo-pitfalls.md](references/set-euo-pitfalls.md)                 |
-| Robustness  | Inverted return codes (0=fail)         | [return-code-convention.md](references/return-code-convention.md)     |
-| Robustness  | set -e in informational scripts        | [return-code-convention.md](references/return-code-convention.md)     |
-| Security    | Variable content used as regex         | [variable-as-regex.md](references/variable-as-regex.md)               |
-| Robustness  | Relative symlinks in git hooks         | [variable-as-regex.md](references/variable-as-regex.md)               |
-| Robustness  | sed for YAML/JSON parsing              | [variable-as-regex.md](references/variable-as-regex.md)               |
-| Security    | Suppression DSL w/o allowlist          | [variable-as-regex.md](references/variable-as-regex.md)               |
-| Security    | CLI arg path traversal                 | [cli-arg-path-traversal.md](references/cli-arg-path-traversal.md)     |
-| Security    | Substring placeholder-exclude          | [security-scanner-fn.md](references/security-scanner-fn.md)           |
-| Security    | Case-restricted security regex         | [security-scanner-fn.md](references/security-scanner-fn.md)           |
-| Security    | Text-only extension filter             | [security-scanner-fn.md](references/security-scanner-fn.md)           |
+| Category    | Anti-Pattern                           | Reference                                                               |
+| ----------- | -------------------------------------- | ----------------------------------------------------------------------- |
+| Security    | eval with untrusted input              | [eval-injection.md](references/eval-injection.md)                       |
+| Security    | Unvalidated command expansion          | [eval-injection.md](references/eval-injection.md)                       |
+| Portability | Platform-specific sed flags            | [portable-sed-and-tools.md](references/portable-sed-and-tools.md)       |
+| Portability | grep -P (Perl regex)                   | [portable-sed-and-tools.md](references/portable-sed-and-tools.md)       |
+| Portability | readarray/mapfile without bash 4 check | [portable-sed-and-tools.md](references/portable-sed-and-tools.md)       |
+| Portability | find -o without grouping               | [find-operator-precedence.md](references/find-operator-precedence.md)   |
+| Robustness  | Division without zero check            | [arithmetic-guards.md](references/arithmetic-guards.md)                 |
+| Robustness  | wc output in arithmetic                | [arithmetic-guards.md](references/arithmetic-guards.md)                 |
+| Robustness  | Missing prerequisite checks            | [prerequisite-checks.md](references/prerequisite-checks.md)             |
+| Robustness  | set -euo edge cases                    | [set-euo-pitfalls.md](references/set-euo-pitfalls.md)                   |
+| Robustness  | grep in pipeline under pipefail        | [set-euo-pitfalls.md](references/set-euo-pitfalls.md)                   |
+| Robustness  | Inverted return codes (0=fail)         | [return-code-convention.md](references/return-code-convention.md)       |
+| Robustness  | set -e in informational scripts        | [return-code-convention.md](references/return-code-convention.md)       |
+| Security    | Variable content used as regex         | [variable-as-regex.md](references/variable-as-regex.md)                 |
+| Robustness  | Relative symlinks in git hooks         | [variable-as-regex.md](references/variable-as-regex.md)                 |
+| Robustness  | sed for YAML/JSON parsing              | [variable-as-regex.md](references/variable-as-regex.md)                 |
+| Security    | Suppression DSL w/o allowlist          | [variable-as-regex.md](references/variable-as-regex.md)                 |
+| Security    | CLI arg path traversal                 | [cli-arg-path-traversal.md](references/cli-arg-path-traversal.md)       |
+| Security    | Substring placeholder-exclude          | [security-scanner-fn.md](references/security-scanner-fn.md)             |
+| Security    | Case-restricted security regex         | [security-scanner-fn.md](references/security-scanner-fn.md)             |
+| Security    | Text-only extension filter             | [security-scanner-fn.md](references/security-scanner-fn.md)             |
+| DRY         | Repeated check+counter blocks          | [dry-patterns.md](references/dry-patterns.md)                           |
+| DRY         | Repeated scan/grep loops               | [dry-patterns.md](references/dry-patterns.md)                           |
+| DRY         | Repeated format+counter pairs          | [dry-patterns.md](references/dry-patterns.md)                           |
+| DRY         | Duplicated constants across scripts    | [shared-libs-and-structure.md](references/shared-libs-and-structure.md) |
+| DRY         | Duplicated dependency checks           | [shared-libs-and-structure.md](references/shared-libs-and-structure.md) |
+| Robustness  | Missing shellcheck source directive    | [shared-libs-and-structure.md](references/shared-libs-and-structure.md) |
 
 ### Step 4: Classify and Report
 
@@ -146,8 +158,8 @@ For EACH issue found:
 Severity classification:
 
 - **CRITICAL**: Security issues (eval injection, command expansion)
-- **MAJOR**: Portability issues that break on common platforms, division by zero
-- **MINOR**: Missing prerequisite checks, set -euo edge cases in non-critical paths
+- **MAJOR**: Portability issues that break on common platforms, division by zero, DRY violations with 5+ repetitions
+- **MINOR**: Missing prerequisite checks, set -euo edge cases in non-critical paths, DRY violations with 3-4 repetitions, missing shellcheck source directives
 
 After all issues, append suggestions (if any) in this format:
 
@@ -178,26 +190,24 @@ After all anti-pattern issues, look for opportunities to simplify or improve
 readability that do not fall into the categories above. Present these as
 **Suggestions** (not errors) — they are optional improvements, not blockers.
 
-Gardener checks:
+Gardener checks (DRY / KISS / structure):
 
-- **Severity as parameter**: two near-identical functions where the only
-  difference is a literal (`p0` vs `warn`, `FAIL` vs `WARN`) — fold into
-  one function with severity as a parameter.
-- **Stringly-typed mode switch**: a function takes a string arg that
-  branches its behavior into 3+ modes (`""` / `"use_whitelist"` / regex).
-  Split into 2–3 named functions calling a shared internal helper.
-- **Dead placeholder state**: a variable declared and initialized (usually
-  `FOO=0`) but never assigned again; often commented as "reserved for
-  future" — delete it and the line that prints it. Re-add when actually
-  needed.
-- **Function mutates caller-scope locals**: a helper reads/writes
-  variables from its caller's scope (`failure_count`, `has_p0_failure`,
-  etc.) via bash dynamic scoping. Convert the helper to a pure function
-  returning a status code (0/1/2); let the caller do the counter update
-  inline or via a tiny local wrapper. Keeps the mutation surface small
-  and explicit.
-- **`$?` capture when not needed later**: `func; rc=$?; if [[ $rc -ne 0 ]]`
-  → `if ! func; then`.
+- **Repeated blocks**: 3+ identical multi-line blocks → extract a helper with `"$@"` forwarding
+- **Scan loops**: same grep-iterate-append body repeated → parameterized scan function
+- **Format+counter**: same string-append + counter-increment → one-line helper
+- **Shared utilities**: same constants/functions in multiple .sh files → `source` a shared lib
+- **Severity as parameter**: separate wrapper functions for p0/warn → one function with severity arg
+- **Stringly-typed mode switch**: function with a string arg branching into 3+ modes (`""` / `"use_whitelist"` / regex) → split into 2–3 named functions calling a shared internal helper
+- **Dead placeholder state**: variable initialized (`FOO=0`) but never reassigned ("reserved for future") → delete it and the line that prints it; re-add when actually needed
+- **Function mutates caller-scope locals**: helper reads/writes caller's vars (`failure_count`, `has_p0_failure`) via bash dynamic scoping → convert to a pure function returning a status code (0/1/2); let the caller update counters inline
+- **`$?` capture**: `func; rc=$?; if [[ $rc -ne 0 ]]` → `if ! func; then` (when return code isn't needed later)
+- **Missing `source` guards**: `source foo.sh` without `# shellcheck source=foo.sh` directive
+
+When proposing DRY improvements, verify the extraction is safe:
+
+- Helpers that modify caller variables must NOT run in subshells (`$(...)` or pipes)
+- `"$@"` forwarding preserves all quoting — prefer it over manual argument passing
+- Only extract when 3+ repetitions exist — premature extraction hurts readability
 
 ---
 

--- a/.claude/skills/bash-reviewer/SKILL.md
+++ b/.claude/skills/bash-reviewer/SKILL.md
@@ -86,6 +86,11 @@ For each script, use `Grep` to scan for pattern signatures:
 | Variable as regex in grep     | `grep ".*\$\w\|grep \$\{`             | Security    |
 | Relative symlink in hooks     | `ln -s .*\.\./`                       | Robustness  |
 | sed for YAML/JSON parsing     | `sed.*---.*---\|sed.*^[a-z]*:`        | Robustness  |
+| CLI arg into path w/o guard   | `--\w+.*"\$2".*\|\$\{[A-Z_]+\}/\$\{`  | Security    |
+| Substring placeholder-exclude | `your_\|example_\|placeholder`        | Security    |
+| Case-restricted security cls  | `\[A-Z_\].*(TOKEN\|KEY\|SECRET)`      | Security    |
+| Text-only extension filter    | `find.*-name.*\.md.*-o.*-name.*\.sh`  | Security    |
+| Suppression w/o allowlist     | `is_nolint\|is_suppressed\|# noqa`    | Security    |
 
 ### Step 3: Read References
 
@@ -109,6 +114,11 @@ For each detected anti-pattern, **READ** the corresponding reference file:
 | Security    | Variable content used as regex         | [variable-as-regex.md](references/variable-as-regex.md)               |
 | Robustness  | Relative symlinks in git hooks         | [variable-as-regex.md](references/variable-as-regex.md)               |
 | Robustness  | sed for YAML/JSON parsing              | [variable-as-regex.md](references/variable-as-regex.md)               |
+| Security    | Suppression DSL w/o allowlist          | [variable-as-regex.md](references/variable-as-regex.md)               |
+| Security    | CLI arg path traversal                 | [cli-arg-path-traversal.md](references/cli-arg-path-traversal.md)     |
+| Security    | Substring placeholder-exclude          | [security-scanner-fn.md](references/security-scanner-fn.md)           |
+| Security    | Case-restricted security regex         | [security-scanner-fn.md](references/security-scanner-fn.md)           |
+| Security    | Text-only extension filter             | [security-scanner-fn.md](references/security-scanner-fn.md)           |
 
 ### Step 4: Classify and Report
 
@@ -167,6 +177,27 @@ Before completing the review, verify:
 After all anti-pattern issues, look for opportunities to simplify or improve
 readability that do not fall into the categories above. Present these as
 **Suggestions** (not errors) — they are optional improvements, not blockers.
+
+Gardener checks:
+
+- **Severity as parameter**: two near-identical functions where the only
+  difference is a literal (`p0` vs `warn`, `FAIL` vs `WARN`) — fold into
+  one function with severity as a parameter.
+- **Stringly-typed mode switch**: a function takes a string arg that
+  branches its behavior into 3+ modes (`""` / `"use_whitelist"` / regex).
+  Split into 2–3 named functions calling a shared internal helper.
+- **Dead placeholder state**: a variable declared and initialized (usually
+  `FOO=0`) but never assigned again; often commented as "reserved for
+  future" — delete it and the line that prints it. Re-add when actually
+  needed.
+- **Function mutates caller-scope locals**: a helper reads/writes
+  variables from its caller's scope (`failure_count`, `has_p0_failure`,
+  etc.) via bash dynamic scoping. Convert the helper to a pure function
+  returning a status code (0/1/2); let the caller do the counter update
+  inline or via a tiny local wrapper. Keeps the mutation surface small
+  and explicit.
+- **`$?` capture when not needed later**: `func; rc=$?; if [[ $rc -ne 0 ]]`
+  → `if ! func; then`.
 
 ---
 

--- a/.claude/skills/bash-reviewer/references/cli-arg-path-traversal.md
+++ b/.claude/skills/bash-reviewer/references/cli-arg-path-traversal.md
@@ -1,0 +1,91 @@
+# CLI Argument Path Traversal Anti-Pattern
+
+## User-Supplied CLI Arg Concatenated Into Filesystem Path
+
+### Anti-Pattern: Unvalidated `--flag <value>` used in path construction
+
+When a CLI flag value is pasted directly into a path (`${BASE}/${ARG}` / `find`
+/ `read`), an attacker (or fat-fingered user) can read or scan arbitrary
+filesystem locations by passing `..`, an absolute path, or `~`.
+
+**Signal:** `case "$1" in --skill|--path|--file|--dir) VAR="$2"; ...` followed
+somewhere by `"${BASE_DIR}/${VAR}"`, `find "$BASE/$VAR"`, `cat "$BASE/$VAR"`,
+or similar, with no validation in between.
+
+```bash
+# BAD: --skill value is pasted into a find root with no guard
+SKILL_FILTER=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skill) SKILL_FILTER="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+# Attacker: `bash lint.sh --skill ../../../etc`
+# → find walks /etc and every file.txt gets secret-scanned / read.
+find "${SKILLS_DIR}/${SKILL_FILTER}" -type f | while read -r f; do
+  scan "$f"
+done
+```
+
+No code is executed, but:
+
+- Arbitrary filesystem read (sensitive files enumerated, small ones printed
+  in error output).
+- CI logs can exfiltrate contents unintentionally.
+- If the tool later adds `rm`, `chmod`, or `cp` on matched files, the blast
+  radius grows.
+
+### Fix: Validate allowed characters OR reject traversal primitives
+
+Reject any value containing `..`, starting with `/` (absolute), or starting
+with `~` (home expansion). For simple names, a whitelist regex is stricter
+and better. Put the guard in a shared lib sourced by every entry point that
+accepts the flag.
+
+```bash
+# scripts/lib/validate-skill-filter.sh — sourced from every entry point.
+validate_skill_filter() {
+  local filter="$1"
+  [[ -z "$filter" ]] && return 0
+  if [[ "$filter" == *".."* ]] || [[ "$filter" == /* ]] || [[ "$filter" == ~* ]]; then
+    echo "ERROR: invalid --skill value: '${filter}' (no '..', absolute, or '~' paths)" >&2
+    exit 1
+  fi
+}
+```
+
+```bash
+# In lint.sh:
+source "$SCRIPT_DIR/lib/validate-skill-filter.sh"
+# ...parse args...
+validate_skill_filter "$SKILL_FILTER"
+```
+
+### Stricter alternative: whitelist regex
+
+If the flag only ever takes a simple identifier (folder name, skill name),
+constrain it with a regex instead of a blacklist:
+
+```bash
+if ! [[ "$SKILL_FILTER" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
+  echo "ERROR: --skill must match [a-z0-9][a-z0-9_-]*" >&2
+  exit 1
+fi
+```
+
+Blacklist is required only when legitimate values include slashes (e.g.
+`.test-fixtures/foo`). Prefer whitelist when they don't.
+
+### Why not just `[[ -d "$path" ]]`?
+
+A dir-exists check stops traversal to non-existent paths but still lets the
+attacker probe for known dirs (`/etc`, `/var/log`, `$HOME/.ssh`). The guard
+must reject the shape of the input, not just its existence.
+
+### Related: env vars, positional args, stdin
+
+The same rule applies to any untrusted string that ends up in a path: `$1`,
+`$LOOKUP_DIR` from env, values read from config files, or lines piped from
+`git diff`. Validate at the boundary, not at the call site.

--- a/.claude/skills/bash-reviewer/references/dry-patterns.md
+++ b/.claude/skills/bash-reviewer/references/dry-patterns.md
@@ -1,0 +1,117 @@
+# Don't repeat check/counter/scan blocks
+
+## Why this is bad
+
+Bash scripts that validate multiple conditions often repeat the same check-invoke-and-count pattern dozens of times. Each repetition is 4-6 lines of boilerplate that obscures the actual check list, inflates the file, and makes it easy to introduce inconsistencies (e.g. forgetting to set a failure flag for one check but not another).
+
+Common duplicated patterns:
+
+- **Check + counter block**: call function, capture `$?`, increment counter, set flag
+- **Scan loop**: iterate files, grep for pattern, append to findings array
+- **Format + counter**: build formatted output string and increment counter
+
+## Bad Example
+
+```bash
+# ❌ BAD: 14 repetitions of the same 5-line block
+check_yaml "$skill_dir" "$yaml_content"
+check_result=$?
+if [[ $check_result -ne 0 ]]; then
+    failure_count=$((failure_count + 1))
+    has_p0_failure=1
+fi
+
+check_required_fields "$name_field" "$desc_field"
+check_result=$?
+if [[ $check_result -ne 0 ]]; then
+    failure_count=$((failure_count + 1))
+    has_p0_failure=1
+fi
+# ... 12 more identical blocks
+
+# ❌ BAD: same scan loop repeated 4 times with only the label different
+for pattern in "${TOKEN_PATTERNS[@]}"; do
+  while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    local line_content
+    line_content=$(grep -inE "$pattern" "$file" 2>/dev/null | head -1 || true)
+    if [[ -n "$line_content" ]]; then
+      issues+=("Secret pattern in ${file#"$dir"/}: $line_content")
+    fi
+  done <<< "$file_list"
+done
+# ... same loop for obfuscation patterns, exfiltration patterns, etc.
+
+# ❌ BAD: same format+counter repeated 14 times
+findings="${findings}\n  ${CYAN}SUGGEST${NC}   [S8] ${count} lines"
+((SUGGESTIONS++)) || true
+# ... same pattern for S10, S15, S16, S19, S20, S21, S22, S23, S24, S25, S26, S27, S28
+```
+
+## Good Example
+
+```bash
+# ✅ GOOD: helper uses "$@" to forward arguments and bash shared scope for counters
+# Severity as parameter — one function handles both blocking and non-blocking checks
+run_check() {
+  local check_name="$1" severity="$2"
+  shift 2
+  if ! "$@"; then
+    failure_count=$((failure_count + 1))
+    [[ "$severity" == "p0" ]] && has_p0_failure=1
+  fi
+}
+
+# 14 checks become 14 single-line calls
+run_check "yaml" p0 check_yaml "$skill_dir" "$yaml_content"
+run_check "required-fields" p0 check_required_fields "$name_field" "$desc_field"
+run_check "no-readme" warn check_no_readme "$skill_dir"
+
+# ✅ GOOD: parameterized scan replaces 4 identical loops
+# Args: label file_list exclude_pattern pattern1 [pattern2 ...]
+scan_files_for_patterns() {
+  local label="$1" file_list="$2" exclude="$3"
+  shift 3
+  for pattern in "$@"; do
+    while IFS= read -r file; do
+      [[ -z "$file" ]] && continue
+      local line_content
+      line_content=$(grep -inE "$pattern" "$file" 2>/dev/null | head -1 || true)
+      if [[ -n "$line_content" ]]; then
+        if [[ -n "$exclude" ]] && echo "$line_content" | grep -qiE "$exclude"; then
+          continue
+        fi
+        issues+=("${label} ${file#"$skill_dir"/}: $line_content")
+      fi
+    done <<< "$file_list"
+  done
+}
+
+scan_files_for_patterns "Secret pattern in" "$files" "" "${TOKEN_PATTERNS[@]}"
+scan_files_for_patterns "Secret pattern in" "$files" "$EXCLUDE" "${ASSIGNMENT_PATTERNS[@]}"
+scan_files_for_patterns "Obfuscation in" "$files" "" "${OBFUSCATION_PATTERNS[@]}"
+
+# ✅ GOOD: format+counter helper eliminates 14 two-line blocks
+suggest() {
+  findings="${findings}\n  ${CYAN}SUGGEST${NC}   [$1] $2"
+  ((SUGGESTIONS++)) || true
+}
+
+suggest "S8" "${count} lines (limit: 500)"
+suggest "S10" "Missing Quality Gate section"
+```
+
+## Key Mechanism: Bash Shared Scope
+
+These helpers work because bash functions share the caller's variable scope (no subshell). `failure_count`, `has_p0_failure`, `findings`, `issues` are modified directly in the calling function's scope. This is safe as long as:
+
+- The helper is called directly (not in a pipe or `$(...)` subshell)
+- Variables are not declared `local` inside the helper if they belong to the caller
+
+## What to look for in code review
+
+- 3+ identical blocks that differ only in function name, label, or arguments
+- `check_result=$?` followed by `if [[ $check_result -ne 0 ]]` — use `if ! func; then` directly
+- Multiple `for pattern in "${ARRAY[@]}"` loops with the same scan body
+- Repeated `string="${string}..."` + `((counter++))` pairs — extract a one-line helper
+- When extracting: prefer severity/mode as a parameter over separate wrapper functions

--- a/.claude/skills/bash-reviewer/references/security-scanner-fn.md
+++ b/.claude/skills/bash-reviewer/references/security-scanner-fn.md
@@ -1,0 +1,159 @@
+# Security Scanner False-Negative Anti-Patterns
+
+Three common ways a regex-based secret/exfil scanner gives a false sense of
+safety: substring exclusions that match partial placeholders, case-restricted
+character classes, and extension filters that skip binaries.
+
+## 1. Substring Placeholder-Exclude
+
+### Anti-Pattern: `grep -iE 'your_|example_|placeholder'` as a post-filter
+
+Post-filtering assignment-pattern matches with an unanchored placeholder
+regex lets secrets through whenever a placeholder prefix happens to appear
+anywhere in the line.
+
+**Signal:** `SECURITY_PLACEHOLDER_EXCLUDE='(your_|example_|<[a-z]|placeholder|...)'`
+used as `grep -iE "$exclude"` on the whole match line.
+
+```bash
+# BAD: `your_` is a substring → whole line skipped
+SECURITY_PLACEHOLDER_EXCLUDE='(your_|example_|<[a-z]|placeholder|\$\{)'
+
+scan_line() {
+  local line="$1"
+  echo "$line" | grep -qiE "$SECURITY_PLACEHOLDER_EXCLUDE" && return 0
+  report_finding "$line"
+}
+
+# All of these are skipped — only the first is a legit placeholder:
+scan_line 'password=your_password'         # OK to skip (placeholder)
+scan_line 'password=your_real_secret_123'  # LEAK — `your_` substring → skipped
+scan_line 'note: copy your_key into .env'  # FP — skipped too (acceptable FP)
+```
+
+### Fix: Extract the RHS and compare against a strict whitelist
+
+Pull the value after `=`, strip quotes, then check against explicit
+placeholder shapes. Real secrets (high-entropy, digits, mixed case) fall
+through to the real check.
+
+```bash
+# Return 0 if the assigned value is a documentation placeholder.
+is_placeholder_rhs() {
+  local line="$1" rhs
+  rhs=$(echo "$line" | sed -E \
+    -e 's/^[0-9]+://' \
+    -e 's/^[^=]*=[[:space:]]*//' \
+    -e 's/^["'"'"']//' \
+    -e 's/["'"'"'[:space:]].*$//')
+  [[ -z "$rhs" ]] && return 1
+
+  case "$rhs" in
+    your_*|example_*|my_*|dummy_*|test_*|sample_*)
+      # Tail must be lowercase+underscore only, ≤30 chars — digits or
+      # mixed case imply a real secret hiding behind a placeholder prefix.
+      [[ "$rhs" =~ ^[a-z_]+$ ]] && [[ ${#rhs} -le 30 ]] && return 0
+      return 1 ;;
+    placeholder|changeme|xxx|xxxxxx|TODO|FIXME|foo|bar) return 0 ;;
+    '<'*) return 0 ;;       # <apikey>
+    '$'*) return 0 ;;       # ${VAR} / $VAR
+    *) return 1 ;;
+  esac
+}
+```
+
+The anti-pattern generalizes: any allowlist post-filter on a scanner should
+be strict (exact or strictly-anchored) rather than substring.
+
+## 2. Case-Restricted Character Classes in Security Regex
+
+### Anti-Pattern: Pattern scans only `[A-Z_]` variable names
+
+Exfiltration regexes that target env-var interpolation (`$TOKEN`, `$API_KEY`)
+often restrict the character class to uppercase. Real scripts use lowercase
+(`$api_token`, `$secret`) freely — they pass the scanner untouched.
+
+**Signal:** security patterns containing `[A-Z_]`, `[A-Z]+`, or
+`\$\{?[A-Z_]` without case-insensitivity.
+
+```bash
+# BAD: only catches $AWS_ACCESS_KEY, misses $aws_access_key
+SECURITY_EXFIL=(
+  'curl.*\$\{?(AWS|SECRET|TOKEN|KEY|PASS|CRED)[A-Z_]*'
+  'curl\s+.*-H\s+.*\$\{?(AUTH|TOKEN|KEY|SECRET|CRED)[A-Z_]*'
+)
+grep -inE "${SECURITY_EXFIL[0]}" scripts/  # silently skips `curl -d "$api_token"`
+```
+
+### Fix: Explicitly allow both cases
+
+Use `[A-Za-z_]` and keep keywords in lowercase (grep already runs with `-i`
+in most scanner harnesses, but making the class explicit documents intent
+and survives copy-paste into case-sensitive grep calls).
+
+```bash
+# GOOD: catches $AWS_*, $aws_*, $Aws_*
+SECURITY_EXFIL=(
+  'curl.*\$\{?(aws|secret|token|key|pass|cred|api|auth)[A-Za-z_]*'
+  'curl\s+.*-H\s+.*\$\{?(auth|token|key|secret|cred)[A-Za-z_]*'
+)
+```
+
+### Why `grep -i` alone is not enough
+
+Even with `grep -i`, a character class like `[A-Z_]` only matches its
+literal members — `-i` makes the match case-insensitive at the literal
+level, not at the class level in all grep implementations. Make the class
+explicit.
+
+## 3. Text-Extension Filter Misses Binary Files
+
+### Anti-Pattern: Scan only `*.md|*.sh|*.json|*.yaml|*.txt`
+
+Secret scanners that `find -name '*.md' -o -name '*.sh' -o ...` skip every
+file without one of those extensions. A committed `.wasm`, `.bin`, `.pfx`,
+`id_rsa`, or an extension-less config file walks past untouched.
+
+**Signal:** `find "$dir" -type f \( -name '*.md' -o -name '*.sh' -o ... \)`
+wrapping a secret-pattern grep.
+
+```bash
+# BAD: narrow extension filter
+text_files=$(find "$dir" -type f \( \
+  -name '*.md' -o -name '*.sh' -o -name '*.py' \
+  -o -name '*.yaml' -o -name '*.yml' -o -name '*.json' \
+  -o -name '*.txt' -o -name '*.toml' \) 2>/dev/null)
+scan_for_secrets "$text_files"
+# → secret in references/keys.pfx or scripts/id_rsa walks through.
+```
+
+### Fix: Two-layered approach
+
+1. **Forbidden-extension blacklist** (P0, unconditional) — reject known
+   secret-shaped files by name/extension without scanning their content.
+
+2. **Opportunistic text detection** — use `file --mime-type` or a text-char
+   heuristic to decide whether to grep a file of unknown extension.
+
+```bash
+# Layer 1: forbid secret-shaped filenames outright.
+SECURITY_FORBIDDEN_EXTENSIONS=(
+  '\.env$' '\.pem$' '\.p12$' '\.pfx$' '\.key$' '\.keystore$' '\.jks$' '\.asc$'
+  'id_rsa' 'id_ed25519' 'id_ecdsa'
+)
+
+# Layer 2: detect text files by content, not extension.
+scan_all_text_files() {
+  local dir="$1"
+  while IFS= read -r file; do
+    if file --mime-type -b "$file" 2>/dev/null | grep -q '^text/'; then
+      scan_for_secrets "$file"
+    fi
+  done < <(find "$dir" -type f)
+}
+```
+
+Multi-line secrets split across lines (`password = \` → next line) are still
+out of reach for a grep-based scanner; document this explicitly in the scan
+function's comment so a reader doesn't assume coverage. Catching them
+requires an AST-aware or context-window AI reviewer.

--- a/.claude/skills/bash-reviewer/references/shared-libs-and-structure.md
+++ b/.claude/skills/bash-reviewer/references/shared-libs-and-structure.md
@@ -1,0 +1,125 @@
+# Don't duplicate utilities across scripts
+
+## Why this is bad
+
+When multiple scripts in the same project define the same color constants, dependency checks, or helper functions, changes must be synchronized across all copies. Missed updates cause silent divergence — one script checks for the right tool version while another doesn't. Copy-pasted code also inflates line counts and makes review harder.
+
+Common duplicated utilities:
+
+- ANSI color constants (RED, GREEN, NC)
+- Tool dependency checks (`command -v jq`, yq version detection)
+- Logging helpers (log_pass, log_fail, log_warn)
+- Argument parsing boilerplate
+
+## Bad Example
+
+```bash
+# ❌ BAD: same color definitions in 4 different scripts
+# lint.sh
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# test-lint.sh (identical copy)
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# structure-check.sh (identical copy, different variable order)
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+# ❌ BAD: yq dependency check duplicated in 3 scripts
+if ! command -v yq >/dev/null 2>&1; then
+  echo "ERROR: yq is required" >&2
+  exit 1
+fi
+if ! yq --version 2>&1 | grep -q 'mikefarah'; then
+  echo "ERROR: Requires mikefarah/yq" >&2
+  exit 1
+fi
+```
+
+## Good Example
+
+```bash
+# ✅ GOOD: shared color constants in one file
+# scripts/lib/colors.sh
+# shellcheck disable=SC2034  # variables used by callers
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# ✅ GOOD: shared dependency check with mode parameter
+# scripts/lib/require-yq.sh
+require_yq() {
+  local missing=""
+  if ! command -v yq >/dev/null 2>&1; then
+    missing="yq is not installed"
+  elif ! yq --version 2>&1 | grep -q 'mikefarah'; then
+    missing="found Python yq, need mikefarah/yq (Go version)"
+  fi
+  [[ -z "$missing" ]] && return 0
+
+  # --warn mode: non-blocking (returns 1 instead of exit 1)
+  if [[ "${1:-}" == "--warn" ]]; then
+    echo -e "${YELLOW}WARN: ${missing} — skipping${NC}"
+    return 1
+  else
+    echo -e "${RED}ERROR: ${missing}${NC}" >&2
+    exit 1
+  fi
+}
+
+# ✅ GOOD: each script sources shared libs
+# shellcheck source=lib/colors.sh
+source "$SCRIPT_DIR/lib/colors.sh"
+# shellcheck source=lib/require-yq.sh
+source "$SCRIPT_DIR/lib/require-yq.sh"
+require_yq          # CI context: fail hard
+require_yq --warn   # pre-commit hook: degrade gracefully
+```
+
+## When to Extract vs. When to Inline
+
+**Extract** when:
+
+- 3+ scripts use the same constants or function
+- The utility has version-sensitive logic (dependency checks)
+- Changes to the utility must apply everywhere simultaneously
+
+**Keep inline** when:
+
+- Only 1-2 scripts use it
+- The "shared" code is a single line (`set -uo pipefail`)
+- Extracting would create a dependency chain harder to understand than the duplication
+
+## Script Structure Principles
+
+**Single Responsibility**: each script does one thing
+
+- `lint.sh` — P0/P1 validation checks
+- `skill-structure.sh` — SUGGEST-only structural analysis
+- `pre-commit.sh` — orchestrates both per staged skill
+
+**Open for Extension**: add checks without changing orchestration
+
+- New check = new `check_*` function + one `run_check` line
+- Severity (`p0`/`warn`) is a parameter, not a separate code path
+
+**Shared libs (`source`)** over copy-paste — but keep the dependency chain shallow:
+
+- `lib/colors.sh` — zero dependencies
+- `lib/require-yq.sh` — depends on colors.sh (for colored output)
+- Scripts source both explicitly with `# shellcheck source=` directives
+
+## What to look for in code review
+
+- Same ANSI color variables defined in multiple .sh files
+- Same `command -v` + version check appearing in multiple scripts
+- Missing `# shellcheck source=` directives on `source` statements
+- Deep source chains (A sources B sources C) — keep to max 2 levels
+- Scripts that could share a dependency check but each implement it differently
+- Functions that accept a mode/severity parameter vs. duplicated wrappers

--- a/.claude/skills/bash-reviewer/references/subprocess-caching.md
+++ b/.claude/skills/bash-reviewer/references/subprocess-caching.md
@@ -1,0 +1,76 @@
+# Subprocess Caching Anti-Pattern
+
+## External Binary Called Multiple Times with Same Input
+
+### Anti-Pattern: Forking expensive binaries (yq, jq, aws, kubectl) repeatedly
+
+Each `$(yq ...)`, `$(jq ...)`, or `$(aws ...)` call forks a new process. On macOS,
+Go binaries like yq take ~100-250ms per fork. Calling the same binary 10+ times per
+iteration in a loop creates measurable slowdowns (seconds per item).
+
+**Signal:** `$(yq ...)` or `$(jq ...)` appearing multiple times with the same source
+file/input, especially inside a `while` or `for` loop.
+
+```bash
+# BAD: 5 yq calls per skill, each forks a new process (~1 sec per skill)
+for skill_dir in skills/*/; do
+  yaml=$(yq --front-matter=extract '.' "$skill_dir/SKILL.md")
+  name=$(printf '%s\n' "$yaml" | yq -r '.name')
+  desc=$(printf '%s\n' "$yaml" | yq -r '.description')
+  agent=$(printf '%s\n' "$yaml" | yq -r '.agent')
+  tools=$(printf '%s\n' "$yaml" | yq -r '.["allowed-tools"]')
+  # ... validate each field
+done
+```
+
+**Fix:** Extract all needed fields in one call, or extract raw YAML once and pass it:
+
+```bash
+# GOOD: 1 yq call for frontmatter, 1 for all fields (tab-separated)
+for skill_dir in skills/*/; do
+  yaml=$(yq --front-matter=extract '.' "$skill_dir/SKILL.md") || continue
+  name=$(printf '%s\n' "$yaml" | yq -r '.name // ""')
+  desc=$(printf '%s\n' "$yaml" | yq -r '.description // ""')
+  # Pass cached values to functions instead of re-extracting
+  validate_name "$name"
+  validate_description "$desc"
+done
+```
+
+```bash
+# BEST: Extract multiple fields in one yq call using JSON output
+fields=$(yq --front-matter=extract -o json '{"name": .name, "desc": .description}' "$file")
+name=$(printf '%s' "$fields" | yq -r '.name')
+desc=$(printf '%s' "$fields" | yq -r '.desc')
+```
+
+### Same Pattern with Other Tools
+
+```bash
+# BAD: aws CLI called in a loop (network + process overhead per call)
+for bucket in "${buckets[@]}"; do
+  size=$(aws s3 ls "s3://$bucket" --summarize | grep "Total Size")
+  count=$(aws s3 ls "s3://$bucket" --summarize | grep "Total Objects")
+done
+
+# GOOD: one call, parse locally
+for bucket in "${buckets[@]}"; do
+  summary=$(aws s3 ls "s3://$bucket" --summarize)
+  size=$(echo "$summary" | grep "Total Size")
+  count=$(echo "$summary" | grep "Total Objects")
+done
+```
+
+### How to Detect
+
+Look for:
+
+1. `$(yq ...)` or `$(jq ...)` appearing 3+ times with the same source file
+2. External binary calls inside `while`/`for` loops that could be hoisted
+3. Functions that extract the same data their caller already extracted
+4. Multiple `extract_field "$yaml" "fieldname"` calls that each fork yq
+
+### Impact
+
+Real example: 8 AI skills × 13 yq calls per skill = 104 forks × ~0.1s = **~10 seconds**.
+After caching: 8 × 3 calls = 24 forks = **~2.5 seconds** (4x faster).

--- a/.claude/skills/bash-reviewer/references/variable-as-regex.md
+++ b/.claude/skills/bash-reviewer/references/variable-as-regex.md
@@ -98,3 +98,91 @@ If yq is not available, document the limitation and use a more robust awk approa
 # ACCEPTABLE: awk-based extraction (handles most cases)
 agent=$(awk '/^---$/{n++; next} n==1 && /^agent:/{sub(/^agent:[[:space:]]*/, ""); print; exit}' "$file")
 ```
+
+## Suppression DSL Without a Critical-Check Allowlist
+
+### Anti-Pattern: `<!-- nolint:... -->` directives that can silence P0 scanners
+
+Any linter that accepts an inline suppression directive (`<!-- nolint:X -->`,
+`# noqa: X`, `// eslint-disable X`, etc.) is a trust boundary: anyone with
+commit rights to a file can disable a check by adding a comment. If the
+dispatch treats every check name equally, a PR can legally land a commit
+that turns off the secret scanner.
+
+**Signal:** `if is_suppressed "$check_name"; then return 0; fi` at the top
+of the dispatch, with no filter on which checks are suppressible.
+
+```bash
+# BAD: any check can be suppressed, including security.
+# Commit message: "chore: fix false positive in docs"
+# Actual diff: `+<!-- nolint:security -->` in SKILL.md
+#              `+AKIAIOSFODNN7EXAMPLE000000000000000000` in same file
+run_check() {
+  local check_name="$1"
+  if is_nolint "$nolint_list" "$check_name"; then
+    log_pass "$check_name (nolint)"   # silent, no audit trail
+    return 0
+  fi
+  "$@"
+}
+```
+
+Two failures compound:
+
+1. **No allowlist of unsuppressible checks** — secret scanning is now
+   opt-out with one line.
+2. **No audit log** — the suppressed check prints as PASS, indistinguishable
+   from a real pass. Reviewers reading CI output won't notice.
+
+### Fix: Deny-list the checks that must always run; log every suppression
+
+Maintain a tight allow-list of checks that cannot be suppressed. When a PR
+tries to suppress one, fail the check AND still run the real scanner — so
+both the intent and (if present) the actual secret are surfaced. For
+suppressible checks, log the suppression with the file path.
+
+```bash
+is_never_suppressible() {
+  case "$1" in
+    security) return 0 ;;   # secret scanning — never suppressible
+    *) return 1 ;;
+  esac
+}
+
+run_check() {
+  local check_name="$1" severity="$2" nolint_list="$3" rel_path="$4"
+  shift 4
+
+  local forced_fail=0
+  if is_nolint "$nolint_list" "$check_name"; then
+    if is_never_suppressible "$check_name"; then
+      log_fail "$check_name" "nolint is not allowed for this check (ignored)"
+      forced_fail=1
+      # Fall through — the real check still runs, so an actual secret in
+      # the same file is also reported. A malicious PR gets two FAIL lines.
+    else
+      log_warn "$check_name" "SUPPRESSED via nolint in $rel_path"
+      return 0
+    fi
+  fi
+
+  if "$@" && [[ $forced_fail -eq 0 ]]; then
+    return 0
+  fi
+  [[ "$severity" == "p0" || $forced_fail -eq 1 ]] && return 2
+  return 1
+}
+```
+
+### Generalizes beyond `nolint`
+
+Same pattern applies to:
+
+- `# type: ignore` / `mypy: disable-error-code` for type checkers
+- `// eslint-disable-next-line` for ESLint
+- `@SuppressWarnings` in Java
+- Custom `skip-ci: <job>` directives in YAML headers
+
+Every one of them needs a hardcoded list of unsuppressible checks (security,
+data-loss prevention, license compliance). The allowlist lives in the tool,
+not in the config, so a repo-level config change can't disable it.

--- a/cross-skill-contracts.yaml
+++ b/cross-skill-contracts.yaml
@@ -1,0 +1,20 @@
+# Cross-Skill Pipeline Contracts
+# Format: upstream | artifact | downstream | format_check
+#
+# Each line declares a data dependency between two skills:
+#   upstream   — skill that produces the artifact
+#   artifact   — file path (relative to project root) produced by upstream
+#   downstream — skill that consumes the artifact
+#   format_check — optional bash command to validate artifact format
+#
+# When no contracts are defined, cross-skill validation passes vacuously (0 contracts = 0 errors).
+#
+# Examples (uncomment when pipeline skills are available):
+#
+# QA Pipeline:
+# repo-scout | audit/repo-scout-report.md | api-test-cases | head -5 | grep -q "^#"
+# api-test-cases | audit/test-scenarios.md | api-tests | head -5 | grep -q "^#"
+# api-tests | src/test/kotlin/ | api-test-review | find {} -name "*.kt" | head -1
+#
+# Go Pipeline (future):
+# golang-codereviewer | audit/code-review.md | golang-tester | head -5 | grep -q "^#"


### PR DESCRIPTION
## Summary

Consolidates two open feature branches for the `/bash-reviewer` skill into a single PR:

- `feat/bash-reviewer-security-audit-patterns` (commit `71b2298`) — 5 security patterns (CLI-arg path traversal, substring placeholder-exclude, case-restricted security regex, text-only extension filter, suppression w/o allowlist) + 4 new reference files + `cross-skill-contracts.yaml` scaffold.
- `feat/bash-reviewer-dry-solid-kiss` (commit `2148b54`) — 5 DRY/KISS/SOLID detection patterns + `dry-patterns.md` + `shared-libs-and-structure.md`.

Conflict resolution (SKILL.md, 3 zones):
- **Detection table** — both rowsets appended (security 5 + DRY 5).
- **References table** — DRY's wider column format adopted; security's 5 rows merged in using the same width.
- **Gardener section** — unioned: DRY's 7 bullets + 3 unique security bullets (stringly-typed mode switch, dead placeholder state, function mutates caller-scope locals). Overlapping items (severity-as-parameter, \`\$?\` capture) deduplicated, keeping the tighter DRY single-line form.

No changes outside `.claude/skills/bash-reviewer/` and the new `cross-skill-contracts.yaml` at repo root.

## Test plan

- [ ] CI: `Skill Quality Pipeline` (agnix + skill-quality + contract-validator) passes.
- [ ] CI: `Golden Tests (T1 Structural)` — shadow mode, warnings OK.
- [ ] Spot-check `.claude/skills/bash-reviewer/SKILL.md`: no conflict markers, all tables render, 10 Gardener bullets.
- [ ] All 6 new reference files present and readable.

After merge: feature branches `feat/bash-reviewer-security-audit-patterns` and `feat/bash-reviewer-dry-solid-kiss` can be deleted (pending confirmation).